### PR TITLE
migration to add indices to inouts table

### DIFF
--- a/database/migrations/2020_03_24_184014_add_indices_to_inouts_table.php
+++ b/database/migrations/2020_03_24_184014_add_indices_to_inouts_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddIndicesToInoutsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('inouts', function (Blueprint $table) {
+            $table->index('entered');
+            $table->index('left');
+            $table->index('token');
+            $table->index('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('inouts', function (Blueprint $table) {
+            $table->dropIndex('inouts_entered_index');
+            $table->dropIndex('inouts_left_index');
+            $table->dropIndex('inouts_token_index');
+            $table->dropIndex('inouts_created_at_index');
+        });
+    }
+}


### PR DESCRIPTION
I'm guessing the inouts table is going to contain ton of records, so it would be nice to have indices.